### PR TITLE
Fix DeclareDesign simulation invocation

### DIFF
--- a/cdmAmsIa/R/ams_ia_simulation.R
+++ b/cdmAmsIa/R/ams_ia_simulation.R
@@ -30,7 +30,7 @@ simulate_ams_ia_dataset <- function(n_users = 20,
         grid_emission_factor = grid_emission_factor
       )
     )
-    data <- DeclareDesign::draw_data(design)
+    data <- design()
   } else {
     user_id <- paste0("user_", seq_len(n_users))
     generation_kwh <- stats::pmax(stats::rnorm(n_users, mean_generation_kwh, sd_generation_kwh), 0)


### PR DESCRIPTION
## Summary
- call the declared DeclareDesign model directly when simulating AMS-I.A data to avoid draw_data errors when only a model step is defined

## Testing
- Not run (Rscript not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e0f7aff1dc8323be4b9782f707880d