### PR TITLE
Add monitoring period aggregation and refresh walkthrough

### DIFF
--- a/PACKAGE_DEVELOPMENT_TEMPLATE.md
+++ b/PACKAGE_DEVELOPMENT_TEMPLATE.md
@@ -17,6 +17,8 @@ This repository hosts a collection of R packages implementing CDM methodologies.
 - Translate **every numbered equation** in the methodology documentation into a dedicated R function stored under `R/`.
 - Provide **meta-functions** that orchestrate the full calculation by composing the equation-level functions.
 - Implement helper functions that evaluate **quantitative applicability conditions** described in the methodology.
+- Include monitoring-period aggregation helpers that roll simulated or observed data up to reporting periods using the
+  equation-level functions.
 - All functions must:
   - Accept tidy data frames (tibbles) as appropriate and return tidyverse-compatible structures.
   - Be vectorised where possible and avoid hidden state.
@@ -35,14 +37,17 @@ This repository hosts a collection of R packages implementing CDM methodologies.
 
 ## 6. Simulation Utilities
 - Each package must expose at least one `simulate_*()` function that creates a test dataset using `DeclareDesign` reflecting the methodology's data requirements.
+- Simulations must emit temporal monitoring metadata (e.g. day, month, and year) so that reporting-period summaries can be reproduced in tests and documentation.
 - Document simulation parameters and default values, emphasising tidyverse compatibility.
 
 ## 7. Vignettes
 - Create a vignette (`vignettes/<package>-methodology.Rmd`) that includes:
   - A narrative description of the methodology and its data requirements.
   - A walkthrough using the simulated dataset and all equation-level functions plus the meta-function.
+  - A section demonstrating monitoring-period aggregation and the accompanying helper function.
   - A diagram (e.g. Mermaid flowchart) showing function interdependencies and data flow.
-  - A function reference table linking to documentation.
+  - A function reference table linking to documentation. Format tabular output using `knitr::kable()` or `gt::gt()` and pair
+    each numbered equation with its LaTeX form alongside the function signature that implements it.
 
 ## 8. Workflow Checklist
 1. Generate the package skeleton with `usethis::create_package()`.

--- a/cdmAmsIa/R/ams_ia_meta.R
+++ b/cdmAmsIa/R/ams_ia_meta.R
@@ -37,3 +37,94 @@ estimate_emission_reductions_ams_ia <- function(generation_data,
     project_emissions = project_emissions
   )
 }
+
+#' Aggregate monitoring results across periods
+#'
+#' Summarises simulated or observed generation data for each monitoring period, returning
+#' baseline generation, emissions, and emission reductions. The helper leverages the
+#' equation-level functions to maintain consistency with AMS-I.A calculations.
+#'
+#' @param generation_data Tibble containing monitoring observations, including the columns
+#'   listed in `group_cols` and `monitoring_cols` plus generation and emission details.
+#' @param monitoring_cols Character vector specifying the columns that define a monitoring period.
+#' @param group_cols Character vector specifying entity-level identifiers (e.g. `user_id`).
+#' @param generation_col Name of the column with electricity generation for each observation in kWh.
+#' @param grid_factor_col Name of the column storing the grid emission factor.
+#' @param project_col Name of the project emissions column (aggregated as the sum across the period).
+#' @return A tibble aggregated by entity and monitoring period with columns for baseline generation,
+#'   baseline emissions, project emissions, and emission reductions.
+#' @examples
+#' data <- simulate_ams_ia_dataset(n_users = 2, n_periods = 3)
+#' aggregate_monitoring_periods(data)
+#' @export
+aggregate_monitoring_periods <- function(generation_data,
+                                         monitoring_cols = c("year", "month"),
+                                         group_cols = "user_id",
+                                         generation_col = "generation_kwh",
+                                         grid_factor_col = "grid_emission_factor",
+                                         project_col = "project_emissions_tco2e") {
+  data_tbl <- tibble::as_tibble(generation_data)
+  keys <- unique(c(group_cols, monitoring_cols))
+  required_cols <- unique(c(keys, generation_col, grid_factor_col, project_col))
+  missing_cols <- setdiff(required_cols, names(data_tbl))
+  if (length(missing_cols) > 0) {
+    stop(
+      sprintf(
+        "`generation_data` is missing required columns: %s",
+        paste(missing_cols, collapse = ", ")
+      ),
+      call. = FALSE
+    )
+  }
+
+  baseline_generation <- calculate_baseline_generation(
+    generation_data = data_tbl,
+    generation_col = generation_col,
+    group_cols = keys
+  )
+
+  grid_and_project <- data_tbl |>
+    dplyr::group_by(dplyr::across(dplyr::all_of(keys))) |>
+    dplyr::summarise(
+      !!grid_factor_col := dplyr::first(rlang::.data[[grid_factor_col]]),
+      !!project_col := sum(rlang::.data[[project_col]], na.rm = TRUE),
+      .groups = "drop"
+    )
+
+  baseline_with_factors <- dplyr::left_join(
+    baseline_generation,
+    grid_and_project,
+    by = keys
+  )
+
+  baseline_emissions <- calculate_baseline_emissions(
+    baseline_generation = baseline_with_factors,
+    grid_emission_factor = baseline_with_factors[[grid_factor_col]],
+    output_col = "baseline_emissions_tco2e"
+  )
+
+  project_summary <- grid_and_project |>
+    dplyr::select(dplyr::all_of(keys), dplyr::all_of(project_col))
+
+  emission_reductions <- calculate_emission_reductions(
+    baseline_emissions = baseline_emissions |>
+      dplyr::select(dplyr::all_of(keys), baseline_emissions_tco2e),
+    project_emissions = project_summary,
+    baseline_col = "baseline_emissions_tco2e",
+    project_col = project_col,
+    output_col = "emission_reductions_tco2e"
+  )
+
+  emission_reductions |>
+    dplyr::left_join(
+      baseline_generation,
+      by = keys
+    ) |>
+    dplyr::left_join(
+      grid_and_project |>
+        dplyr::select(dplyr::all_of(keys), dplyr::all_of(grid_factor_col)),
+      by = keys
+    ) |>
+    dplyr::relocate(dplyr::all_of(keys)) |>
+    dplyr::arrange(dplyr::across(dplyr::all_of(keys)))
+}

--- a/cdmAmsIa/R/ams_ia_simulation.R
+++ b/cdmAmsIa/R/ams_ia_simulation.R
@@ -6,10 +6,13 @@
 #' electricity use.
 #'
 #' @param n_users Number of end users to simulate.
+#' @param n_periods Number of monitoring periods (default monthly observations across a year).
+#' @param start_year Calendar year assigned to the first monitoring period.
+#' @param start_month Calendar month (1-12) assigned to the first monitoring period.
 #' @param mean_generation_kwh Mean annual electricity generation per user in kWh.
 #' @param sd_generation_kwh Standard deviation of annual electricity generation.
 #' @param grid_emission_factor Grid emission factor in tCO2e/kWh used for simulated emissions.
-#' @return A tibble containing simulated user identifiers, generation, and emissions.
+#' @return A tibble containing simulated user identifiers, monitoring period metadata, generation, and emissions.
 #' @examples
 #' simulate_ams_ia_dataset(n_users = 5)
 #' @importFrom DeclareDesign declare_model
@@ -19,6 +22,9 @@
 #' @importFrom dplyr mutate
 #' @export
 simulate_ams_ia_dataset <- function(n_users = 20,
+                                    n_periods = 12,
+                                    start_year = 2023,
+                                    start_month = 1,
                                     mean_generation_kwh = 15000,
                                     sd_generation_kwh = 2000,
                                     grid_emission_factor = 0.75) {
@@ -26,17 +32,43 @@ simulate_ams_ia_dataset <- function(n_users = 20,
     stop("`n_users` must be a positive numeric value.", call. = FALSE)
   }
 
+  if (!is.numeric(n_periods) || n_periods <= 0) {
+    stop("`n_periods` must be a positive numeric value.", call. = FALSE)
+  }
+
+  if (!start_month %in% 1:12) {
+    stop("`start_month` must be between 1 and 12.", call. = FALSE)
+  }
+
   design <- declare_model(
     users = add_level(
       N = n_users,
       user_id = paste0("user_", seq_len(n_users)),
-      generation_kwh = pmax(rnorm(n_users, mean_generation_kwh, sd_generation_kwh), 0),
       grid_emission_factor = grid_emission_factor
+    ),
+    monitoring_periods = add_level(
+      N = n_periods,
+      monitoring_period = seq_len(N),
+      period_index = seq_len(N),
+      year = start_year + ((start_month - 1L + period_index - 1L) %/% 12L),
+      month = ((start_month - 1L + period_index - 1L) %% 12L) + 1L,
+      day = sample.int(28L, size = N, replace = TRUE),
+      monitoring_date = as.Date(sprintf("%04d-%02d-%02d", year, month, day)),
+      monitoring_label = sprintf("%04d-%02d", year, month),
+      generation_kwh = pmax(
+        stats::rnorm(
+          n = N,
+          mean = mean_generation_kwh / n_periods,
+          sd = sd_generation_kwh / sqrt(n_periods)
+        ),
+        0
+      )
     )
   )
 
   design() |>
     as_tibble() |>
+    dplyr::select(-period_index) |>
     mutate(
       baseline_generation_kwh = generation_kwh,
       baseline_emissions_tco2e = baseline_generation_kwh * grid_emission_factor,

--- a/cdmAmsIa/tests/testthat/test_simulation.R
+++ b/cdmAmsIa/tests/testthat/test_simulation.R
@@ -1,8 +1,32 @@
 
 test_that("simulation generates expected columns", {
   set.seed(123)
-  data <- simulate_ams_ia_dataset(n_users = 5)
+  data <- simulate_ams_ia_dataset(n_users = 5, n_periods = 2, start_year = 2024, start_month = 6)
   expect_s3_class(data, "tbl_df")
-  expect_true(all(c("user_id", "generation_kwh", "baseline_emissions_tco2e", "emission_reductions_tco2e") %in% names(data)))
+  expected_cols <- c(
+    "user_id", "monitoring_period", "year", "month", "day", "monitoring_date",
+    "monitoring_label", "generation_kwh", "baseline_emissions_tco2e", "emission_reductions_tco2e"
+  )
+  expect_true(all(expected_cols %in% names(data)))
+  expect_equal(unique(data$year), 2024)
+  expect_equal(sort(unique(data$month)), c(6, 7))
   expect_true(all(data$emission_reductions_tco2e >= 0))
+})
+
+test_that("monitoring aggregation returns period summaries", {
+  set.seed(321)
+  data <- simulate_ams_ia_dataset(n_users = 2, n_periods = 3)
+  summary <- aggregate_monitoring_periods(
+    generation_data = data,
+    monitoring_cols = c("monitoring_label"),
+    group_cols = "user_id"
+  )
+
+  expect_s3_class(summary, "tbl_df")
+  expect_true(all(c(
+    "user_id", "monitoring_label", "baseline_generation_kwh", "baseline_emissions_tco2e",
+    "project_emissions_tco2e", "emission_reductions_tco2e", "grid_emission_factor"
+  ) %in% names(summary)))
+  expect_equal(nrow(summary), 2 * 3)
+  expect_true(all(summary$emission_reductions_tco2e >= 0))
 })

--- a/cdmAmsIa/vignettes/cdmAmsIa-methodology.Rmd
+++ b/cdmAmsIa/vignettes/cdmAmsIa-methodology.Rmd
@@ -31,9 +31,16 @@ check_applicability_distributed_generation(fossil_fraction_baseline = 0.85)
 
 ```{r simulation}
 set.seed(123)
-example_data <- simulate_ams_ia_dataset(n_users = 10)
-head(example_data)
+example_data <- simulate_ams_ia_dataset(n_users = 6, n_periods = 4, start_year = 2024, start_month = 10)
+knitr::kable(
+  head(example_data),
+  format = "html",
+  digits = 2
+)
 ```
+
+The simulation now includes explicit monitoring metadata (`monitoring_period`, `year`, `month`,
+`day`, and `monitoring_label`) so that calculations can be aggregated over reporting periods.
 
 # Equation Walkthrough
 
@@ -42,7 +49,19 @@ baseline_gen <- calculate_baseline_generation(example_data, group_cols = "user_i
 baseline_emis <- calculate_baseline_emissions(baseline_gen, grid_emission_factor = 0.75)
 project_emis <- calculate_project_emissions(baseline_gen)
 emission_reductions <- calculate_emission_reductions(baseline_emis, project_emis)
-head(emission_reductions)
+knitr::kable(head(emission_reductions), format = "html", digits = 2)
+```
+
+# Monitoring Period Aggregation
+
+```{r monitoring}
+period_summary <- aggregate_monitoring_periods(
+  generation_data = example_data,
+  monitoring_cols = c("monitoring_label"),
+  group_cols = "user_id"
+)
+
+knitr::kable(head(period_summary), format = "html", digits = 2)
 ```
 
 # Meta-Function
@@ -57,14 +76,41 @@ estimate_emission_reductions_ams_ia(
 
 # Function Reference
 
-| Function | Purpose |
-|----------|---------|
-| `calculate_baseline_generation()` | Equation (1): Aggregates electricity generation |
-| `calculate_baseline_emissions()` | Equation (2): Baseline emissions |
-| `calculate_project_emissions()` | Equation (3): Project emissions |
-| `calculate_emission_reductions()` | Equation (4): Emission reductions |
-| `estimate_emission_reductions_ams_ia()` | Meta-calculation |
-| `simulate_ams_ia_dataset()` | DeclareDesign-based simulation |
+```{r reference}
+function_reference <- tibble::tribble(
+  ~Function, ~Signature, ~`Equation (LaTeX)`, ~Purpose,
+  "`calculate_baseline_generation()`",
+  "`calculate_baseline_generation(generation_data, generation_col = \"generation_kwh\", group_cols = NULL)`",
+  "\\(E_{BL,mp} = \\sum_{i} G_{i,mp}\\)",
+  "Summed baseline generation for each group or monitoring period.",
+  "`calculate_baseline_emissions()`",
+  "`calculate_baseline_emissions(baseline_generation, grid_emission_factor, output_col = \"baseline_emissions_tco2e\")`",
+  "\\(E_{BL,mp}^{CO2} = E_{BL,mp} \times EF_{grid}\\)",
+  "Baseline emissions using the applicable grid factor.",
+  "`calculate_project_emissions()`",
+  "`calculate_project_emissions(baseline_generation, project_emission_factor = 0, output_col = \"project_emissions_tco2e\")`",
+  "\\(E_{PR,mp}^{CO2} = E_{BL,mp} \times EF_{PR}\\)",
+  "Project emissions (typically zero for AMS-I.A).",
+  "`calculate_emission_reductions()`",
+  "`calculate_emission_reductions(baseline_emissions, project_emissions, baseline_col = \"baseline_emissions_tco2e\", project_col = \"project_emissions_tco2e\", output_col = \"emission_reductions_tco2e\")`",
+  "\\(ER_{mp} = E_{BL,mp}^{CO2} - E_{PR,mp}^{CO2}\\)",
+  "Emission reductions for each monitoring period.",
+  "`aggregate_monitoring_periods()`",
+  "`aggregate_monitoring_periods(generation_data, monitoring_cols = c(\"year\", \"month\"), group_cols = \"user_id\")`",
+  "\\(ER_{mp}^{agg} = \\sum_{i} ER_{i,mp}\\)",
+  "Aggregates monitoring data to reporting periods.",
+  "`estimate_emission_reductions_ams_ia()`",
+  "`estimate_emission_reductions_ams_ia(generation_data, grid_emission_factor, project_emission_factor = 0, group_cols = NULL)`",
+  "\\(ER_{total} = \\sum_{mp} ER_{mp}\\)",
+  "Meta-calculation composing the core equations.",
+  "`simulate_ams_ia_dataset()`",
+  "`simulate_ams_ia_dataset(n_users = 20, n_periods = 12, start_year = 2023, start_month = 1, mean_generation_kwh = 15000, sd_generation_kwh = 2000, grid_emission_factor = 0.75)`",
+  "\\(G_{i,mp} \sim \mathcal{N}(\mu_{G}/P, \sigma_{G}/\\sqrt{P})\\)",
+  "DeclareDesign-based simulation with temporal monitoring metadata."
+)
+
+knitr::kable(function_reference, format = "html", escape = FALSE)
+```
 
 # Workflow Diagram
 


### PR DESCRIPTION
## Summary
- add temporal monitoring metadata to the AMS-I.A simulation utility and support vector grid factors for baseline emissions
- introduce a monitoring-period aggregation helper and refresh the vignette with formatted tables, LaTeX equations, and reporting-period summaries
- update the package template and tests to cover the new monitoring workflow requirements

## Testing
- Rscript -e "testthat::test_dir('cdmAmsIa/tests/testthat', reporter = 'summary')" *(fails: package 'testthat' is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e11664b0f08323a2c78394e5c5e797